### PR TITLE
fix startup error during npm start

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "node server",
   "main": "index.js",
   "scripts": {
-    "start": "node server.bundle.js",
+    "start": "node server.js",
     "build": "webpack",
     "dev": "nodemon ./server.js localhost 3080",
     "test": "echo \"Error: no test specified\" && exit 1"


### PR DESCRIPTION
Fix for "file not found" error during npm start because of wrong filename in start script.
Relating to #8 
Should not affect docker startup.